### PR TITLE
:bug:  fix lint rule conflict between eslint and typescript-eslit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,8 @@ module.exports = {
     'no-irregular-whitespace': 0, //不规则的空白不允许
     'no-trailing-spaces': 1, //一行结束后面有空格就发出警告
     'eol-last': 0, //文件以单一的换行符结束
-    'no-unused-vars': [2, { vars: 'all', args: 'after-used' }], //不能有声明后未被使用的变量或参数
+    'no-unused-vars': [0], //不能有声明后未被使用的变量或参数
+    '@typescript-eslint/no-unused-vars': [2, { vars: 'all', args: 'after-used' }],
     'no-underscore-dangle': 0, //标识符不能以_开头或结尾
     'no-alert': 2, //禁止使用alert confirm prompt
     'no-lone-blocks': 0, //禁止不必要的嵌套块


### PR DESCRIPTION
- 修复 eslint 和 typescript-eslint 中的规则冲突，导致 eslint 对 typescript 中的类型定义报 lint error。详情见[typescript-eslint FAQ](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-am-using-a-rule-from-eslint-core-and-it-doesnt-work-correctly-with-typescript-code)